### PR TITLE
feat(generate): add types for making `param` callable

### DIFF
--- a/packages/generate/src/syntax/params.ts
+++ b/packages/generate/src/syntax/params.ts
@@ -157,11 +157,26 @@ export function params<
     returnExpr = select(returnExpr) as any;
   }
 
-  return $expressionify({
+  const withParamsExpr = $expressionify({
     __kind__: ExpressionKind.WithParams,
     __element__: returnExpr.__element__,
     __cardinality__: returnExpr.__cardinality__,
     __expr__: returnExpr,
     __params__: Object.values(paramExprs),
   }) as any;
+
+  const callableExpr = function (args: paramsToInputArgs<Params>) {
+    return $expressionify({
+      __kind__: ExpressionKind.WithParams,
+      __element__: returnExpr.__element__,
+      __cardinality__: returnExpr.__cardinality__,
+      __expr__: returnExpr,
+      __params__: Object.values(paramExprs),
+      __args__: args,
+    }) as any;
+  };
+
+  Object.assign(callableExpr, withParamsExpr);
+
+  return callableExpr as any;
 }

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -866,6 +866,25 @@ function renderEdgeQL(
   if (expr.__kind__ === ExpressionKind.With) {
     return renderEdgeQL(expr.__expr__, ctx);
   } else if (expr.__kind__ === ExpressionKind.WithParams) {
+    if ((expr as any).__args__) {
+      const argList = Object.entries((expr as any).__args__)
+        .map(([key, value]) => {
+          if (
+            value &&
+            typeof value === "object" &&
+            (value as any).__kind__ === ExpressionKind.Param
+          ) {
+            return `  __param__${key} := ${renderEdgeQL(value as any, ctx)}`;
+          }
+          const param = expr.__params__.find(
+            (p: any) => p.__name__ === key,
+          ) as any;
+          return `  __param__${key} := ${literalToEdgeQL(param.__element__, value)}`;
+        })
+        .join(",\n");
+
+      return `(WITH\n${argList}\nSELECT ${renderEdgeQL(expr.__expr__, ctx)})`;
+    }
     return `(WITH\n${expr.__params__
       .map((param) => {
         const optional =


### PR DESCRIPTION
Makes `param` result callable on the type level, includes TS and Param types for composability